### PR TITLE
Support for  chunked snapshots

### DIFF
--- a/chunked-demo/__snapshots__/spec.a.js
+++ b/chunked-demo/__snapshots__/spec.a.js
@@ -1,0 +1,1 @@
+exports['chunked-snapshot-demo [a] 1'] = 101

--- a/chunked-demo/__snapshots__/spec.b.js
+++ b/chunked-demo/__snapshots__/spec.b.js
@@ -1,0 +1,1 @@
+exports['chunked-snapshot-demo [b] 1'] = 33

--- a/chunked-demo/spec.js
+++ b/chunked-demo/spec.js
@@ -1,0 +1,17 @@
+const snapshot = require('../src')
+const la = require('lazy-ass')
+
+it('spec-a with chunked snapshot', () => {
+  snapshot({title: 'chunked-snapshot-demo', chunk: 'a'}, 101)
+})
+
+it('spec-b with chunked snapshot', () => {
+  snapshot({title: 'chunked-snapshot-demo', chunk: 'b'}, 33)
+})
+
+after(() => {
+  const snapshots_a = require('./__snapshots__/spec.a')
+  la(snapshots_a['chunked-snapshot-demo [a] 1'] === 101, 'wrong snapshot', snapshots_a)
+  const snapshots_b = require('./__snapshots__/spec.b')
+  la(snapshots_b['chunked-snapshot-demo [b] 1'] === 33, 'wrong snapshot', snapshots_b)
+})

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "license": "license-checker --production --onlyunknown --csv",
     "lint": "standard --verbose --fix src/*.js",
     "named-demo": "cd named-demo; mocha spec*.js",
+    "chunked-demo": "cd chunked-demo; mocha spec*.js",
     "ts-demo": "cd ts-demo; npm ci; npm test",
     "coffee-demo": "cd coffee-demo; npm ci; npm test",
     "postlint": "eslint --fix src/*.js",

--- a/src/chunked-snapshots.js
+++ b/src/chunked-snapshots.js
@@ -1,0 +1,10 @@
+function isChunkedSnapshotArguments (args) {
+  return (
+    args.length === 2 &&
+    typeof args[0] === 'object' &&
+    (args[0].title || args[0].chunk)
+  )
+}
+
+// eslint-disable-next-line immutable/no-mutation
+module.exports = { isChunkedSnapshotArguments }

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ const debug = require('debug')('snap-shot-it')
 const { core, restore, prune } = require('snap-shot-core')
 const { isDataDriven, dataDriven } = require('@bahmutov/data-driven')
 const { isNamedSnapshotArguments } = require('./named-snapshots')
+const { isChunkedSnapshotArguments } = require('./chunked-snapshots')
 const utils = require('./utils')
 const R = require('ramda')
 const { hasOnly, hasFailed } = require('has-only')
@@ -195,6 +196,18 @@ function snapshot (value) {
     savedTestTitle = arguments[0]
     value = arguments[1]
     debug('named snapshots "%s"', savedTestTitle)
+  } else if (isChunkedSnapshotArguments(arguments)) {
+    if (arguments[0].title) savedTestTitle = arguments[0].title
+    const chunk = arguments[0].chunk
+    if (chunk) {
+      const parsedPath = path.parse(currentTest.file)
+      currentTest.file = `${path.join(
+        parsedPath.dir,
+        parsedPath.name + '.' + chunk + parsedPath.ext
+      )}`
+      savedTestTitle += ` [${chunk}]`
+    }
+    value = arguments[1]
   } else {
     debug('snapshot value %j', value)
   }


### PR DESCRIPTION
A possible solution for https://github.com/bahmutov/snap-shot-it/issues/405
Option to create a chunked snapshot which will break big snapshot files to small chunks

e.g.
`snapshot({title: 'snapshot-title', chunk: 'chunk-1'}, data)`
`snapshot({title: 'snapshot-title', chunk: 'chunk-2'}, data)`
It will create 2 chunks for `test.js` will be `test.chunk-1.js` & `test.chunk-2.js`