### PR TITLE
fix: if all tests are skipped do not crash in afterAll hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache:
     - ~/.npm
 notifications:
   email: true
-node_js: '10'
+node_js: '12'
 
 stages:
   - 'Tests'
@@ -19,6 +19,7 @@ script:
   - DEBUG=snap-shot-it npm run test-two-specs
   - npm run ts-demo
   - npm run coffee-demo
+  - cd test-all-skipped && npm test
 
 jobs:
   fail_fast: true

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,8 @@ const relativeToCwd = path.relative.bind(null, cwd)
 debug('loading snap-shot-it')
 const EXTENSION = '.js'
 
+const noop = () => {}
+
 /**
  * all tests we have seen so we can prune later
  * for each seen spec we keep just an object
@@ -41,7 +43,7 @@ function _pruneSnapshots () {
 }
 
 // eslint-disable-next-line immutable/no-let
-let pruneSnapshots
+let pruneSnapshots = noop
 let pruneSnapshotsOptions
 
 /**
@@ -141,10 +143,10 @@ global.beforeEach(function () {
   /* eslint-disable immutable/no-this */
   if (hasOnly(this)) {
     debug('skip pruning snapshots because found .only')
-    pruneSnapshots = function noop () {}
+    pruneSnapshots = noop
   } else if (utils.isPruningDisabled()) {
     debug('skip pruning snapshots by env variable')
-    pruneSnapshots = function noop () {}
+    pruneSnapshots = noop
   } else {
     debug('will prune snapshots because no .only')
     pruneSnapshots = _pruneSnapshots
@@ -344,6 +346,11 @@ global.after(function () {
   /* eslint-disable immutable/no-this */
   if (!hasFailed(this)) {
     debug('the test run was a success')
+    la(
+      is.fn(pruneSnapshots),
+      'expected pruneSnapshots to be a function',
+      pruneSnapshots
+    )
     pruneSnapshots.call(this)
   } else {
     debug('not attempting to prune snapshots because the test run has failed')

--- a/test-all-skipped/README.md
+++ b/test-all-skipped/README.md
@@ -1,0 +1,1 @@
+# test-all-skipped

--- a/test-all-skipped/package.json
+++ b/test-all-skipped/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "test-all-skipped",
+  "version": "1.0.0",
+  "description": "testing situation when all tests are skipped",
+  "main": "index.js",
+  "scripts": {
+    "test": "../node_modules/.bin/mocha 'specs/**/*.js'"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/test-all-skipped/specs/spec.js
+++ b/test-all-skipped/specs/spec.js
@@ -1,0 +1,5 @@
+const snapshot = require('../..')
+
+/* eslint-env mocha */
+it.skip('is skipped 1', () => {})
+it.skip('is skipped 2', () => {})


### PR DESCRIPTION
trying to use prunt hook that was never set (because there was no `beforeEach` hook executed to set it)
- closes #496 